### PR TITLE
Add queryselectors, rename classes to match

### DIFF
--- a/game.js
+++ b/game.js
@@ -36,7 +36,7 @@ class Game {
     this.gameIsADraw = false
     this.currentPlayer = this.playerOne
     this.startsNextGame = this.playerTwo
-    this.turnCounter = 8;
+    this.turnCounter = 0;
     this.weHaveAWinner = false;
   }
 

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     </section>
     <section class='game-board-section'>
       <header>
-        <h1 class='player-turn/win/draw'>Players Turn/Win/draw</h1>
+        <h1 class='player-turn-win-draw'>Players Turn/Win/draw</h1>
       </header>
       <span class='game-board'>
         <div class='game-space space-a' id="a">

--- a/main.js
+++ b/main.js
@@ -1,27 +1,28 @@
 
 var gameBoard = document.querySelector('.game-board')
-var header = document.querySelector('.player-turn/win/draw')
+var header = document.querySelector('.player-turn-win-draw')
+var gameSpace = document.querySelectorAll('.game-space')
+var player1NumOfWins = document.querySelector('.player1-number-of-wins')
+var player2NumOfWins = document.querySelector('.player2-number-of-wins')
 
 var game = new Game()
 
 gameBoard.addEventListener('click', function(e){
   displayMove(e)
 })
+
 function displayMove(e) {
   var letter = document.getElementById(e.target.id)
   console.log(e.target.id)
     game.makeAMove(e.target.id)
-    letter.innerHTML += `<img class='player2-token-image' src='./assets/${game.currentPlayer.token}.png' alt='' />`
+    letter.innerHTML = `<img class='player2-token-image' src='./assets/${game.currentPlayer.token}.png' alt='' />`
     game.checkForWin()
 
 }
+
 function displayWinner() {
   if (game.weHaveAWinner === true) {
-    header.innerText= `${game.currentPlayer.id} Wins!!!`
-  }
-}
-function displayDraw() {
-  if (game.gameIsADraw === true) {
-
+    header.innerText = `${game.currentPlayer.id} Wins!!!`
+    reset()
   }
 }


### PR DESCRIPTION
# Description

Add queryselectors, rename classes to match.

Fixes # (issue) Had to rename classes of elements to avoid confusion between spaces, and for future reset() function.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
